### PR TITLE
Fix package name in cabal file.

### DIFF
--- a/mnist-idx.cabal
+++ b/mnist-idx.cabal
@@ -1,4 +1,4 @@
-name:                minst-idx
+name:                mnist-idx
 
 version:             0.1.2.2
 


### PR DESCRIPTION
When the minst typo was fixed it was missed in the name: field of the cabal file.
