### PR TITLE
bumped version bounds on directory and vector for compatibility with stackage

### DIFF
--- a/mnist-idx.cabal
+++ b/mnist-idx.cabal
@@ -58,7 +58,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <5,
                        binary >= 0.7 && < 0.9,
-                       vector >= 0.10 && < 0.12,
+                       vector >= 0.10 && < 0.13,
                        bytestring >= 0.10 && < 0.11 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -76,7 +76,7 @@ test-suite tests
 
   build-depends:       base >= 4.6
                      , hspec >= 1.9
-                     , vector >= 0.10 && < 0.12
+                     , vector >= 0.10 && < 0.13
                      , binary >= 0.7 && < 0.9
-                     , directory >= 1.2 && < 1.3
+                     , directory >= 1.2 && < 1.4
                      , mnist-idx


### PR DESCRIPTION
Thanks for the library!  Was trying to use it in one of my benchmark/test suites for a stackage project, and noticed that at the moment stackage requires `directory-1.3.0.0` and `vector-0.12.0.1` (from https://github.com/fpco/stackage/pull/2372#issuecomment-286907706).  Hope you don't mind!  I ran the test suite and it looks like there aren't any regressions from using the updated *directory*/*vector* versions, from what I can tell.