### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/mnist-idx.cabal
+++ b/mnist-idx.cabal
@@ -38,7 +38,7 @@ build-type:          Simple
 -- extra-source-files:  
 
 -- Constraint on the version of Cabal needed to build this package.
-cabal-version:       >= 1.16
+cabal-version:       >= 1.10
 
 source-repository head
   type:              git
@@ -52,11 +52,12 @@ library
   -- Modules included in this library but not exported.
   -- other-modules:
   
+  default-language: Haskell2010
   -- LANGUAGE extensions used by modules in this package.
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <5,
+  build-depends:       base >=4.8 && <5,
                        binary >= 0.7 && < 0.9,
                        vector >= 0.10 && < 0.13,
                        bytestring >= 0.10 && < 0.11 


### PR DESCRIPTION
Currently this package doesn't work w/ pre-AMP `base` versions:
(while at it, this also sets a more sensible `cabal-version` value and silences the warning about `default-language` missing)

```
Configuring component lib from mnist-idx-0.1.2.7...
Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
Preprocessing library mnist-idx-0.1.2.7...
[1 of 2] Compiling Data.IDX.Internal ( src/Data/IDX/Internal.hs, /tmp/matrix-worker/1490622584/dist-newstyle/build/x86_64-linux/ghc-7.8.4/mnist-idx-0.1.2.7/build/Data/IDX/Internal.o )

src/Data/IDX/Internal.hs:70:35: Not in scope: ‘<$>’

src/Data/IDX/Internal.hs:73:62: Not in scope: ‘<$>’

src/Data/IDX/Internal.hs:113:28: Not in scope: ‘<$>’

src/Data/IDX/Internal.hs:114:55: Not in scope: ‘<$>’

src/Data/IDX/Internal.hs:210:51: Not in scope: ‘<$>’

src/Data/IDX/Internal.hs:224:49: Not in scope: ‘<$>’

```